### PR TITLE
collections.Mapping was removed in Python 3.9

### DIFF
--- a/src/sentaku/utils.py
+++ b/src/sentaku/utils.py
@@ -2,8 +2,13 @@
 
     utility classes for implementation lookup
 """
-from collections import Mapping
+import sys
 import attr
+
+if sys.version_info[0] == 3:
+    from collections.abc import Mapping
+else:
+    from collections import Mapping
 
 
 @attr.s(frozen=True)


### PR DESCRIPTION
Make a backwards compatible import.