### PR TITLE
Fix _get_implementation_for to catch KeyError

### DIFF
--- a/src/sentaku/context.py
+++ b/src/sentaku/context.py
@@ -109,7 +109,7 @@ class ImplementationContext:
     def _get_implementation_for(self, key: object) -> ImplementationChoice:
         try:
             implementation_set = self.__combined_registrations[key]
-        except AttributeError:
+        except (AttributeError, KeyError):
             combined: dict[object, dict[object, object]] = {}
             context_cls: type[ImplementationContext]
             for context_cls in reversed(type(self).__mro__):


### PR DESCRIPTION
This PR fixes `_get_implementation_for` to resolve an issue in which contextual methods from two different modules are used. If those modules are imported dynamically, then the first contextual method will be registered and then accessed via `_get_implementation_for`, which creates and sets the `__combined_registrations` attribute.

When the module for the second contextual method is then imported, more contextual methods are registered, and the second call to `_get_implementation_for` throws a `KeyError` when checking if the contextual method is in `__combined_registrations`. Currently, only `AttributeError` is handled, which only happens when initially setting the attribute.