### PR TITLE
Fix catalog-info.yaml files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,10 @@ repos:
       rev: v3.9.0
       hooks:
           - id: reorder-python-imports
-            args: [--application-directories=.:examples:src, --py38-plus]
+            args:
+                - --application-directories=.:examples:src
+                - --py38-plus
+
     - repo: https://github.com/psf/black
       rev: 23.1.0
       hooks:
@@ -43,3 +46,16 @@ repos:
       rev: 0.9.1
       hooks:
           - id: pyproject-fmt
+
+    # Backstage linter
+    - repo: local
+      hooks:
+          - id: backstage-entity-validator
+            name: backstage-entity-validator
+            language: system
+            files: catalog-info\.yaml$
+            entry: npx @roadiehq/backstage-entity-validator validate-entity
+            exclude: |
+                (?x)^(
+                  user_repo.*
+                )$

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -2,24 +2,26 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: Sentaku
-  description: Model Applications under Test using python for e2e testing
-  links:
-    - title: docs
-      url: https://sentaku.readthedocs.io/
-      icon: docs
-    - title: code
-      url: https://github.com/RedhatQE/Sentaku
-      icon: github
-    - title: pypi
-      url: https://pypi.org/project/sentaku/
-  tags:
-    - test-framework
-    - python
-  namespace: quality-community
-  annotations:
-    github.com/project-slug: RedhatQE/Sentaku
+    name: Sentaku
+    description: Model Applications under Test using python for e2e testing
+    links:
+        - title: docs
+          url: https://sentaku.readthedocs.io/
+          icon: docs
+        - title: code
+          url: https://github.com/RedhatQE/Sentaku
+          icon: github
+        - title: pypi
+          url: https://pypi.org/project/sentaku/
+    tags:
+        - test-framework
+        - python
+    namespace: quality-community
+    annotations:
+        github.com/project-slug: RedhatQE/Sentaku
     # backstage.io/techdocs-ref: < dir:location where docs dir and mkdocs.yml reside e.g . OR ./sub-folder no space after dir:>
 spec:
-  owner: user:redhat/rpfannsc
-  domain: quality-community/quality-community
+    type: component
+    lifecycle: production
+    owner: user:redhat/rpfannsc
+    domain: quality-community/quality-community


### PR DESCRIPTION
The `catalog-info.yaml` file is invalid, make sure it passes basic sanity from the backstage pre-commit validation:

https://console.one.redhat.com/docs/quality-community/Component/qe-toolbelt-catalog/onboarding/#pre-commit

Also fix additional formatting found by running pre-commit on the changed files :)